### PR TITLE
Spring Framework와 의존성 주입 활용

### DIFF
--- a/toby-spring/src/main/java/spring/practice/tobyspring/DI/CalculatorService.java
+++ b/toby-spring/src/main/java/spring/practice/tobyspring/DI/CalculatorService.java
@@ -1,0 +1,5 @@
+package spring.practice.tobyspring.DI;
+
+public interface CalculatorService {
+    public int add(int value1, int value2);
+}

--- a/toby-spring/src/main/java/spring/practice/tobyspring/DI/NormalCalculatorService.java
+++ b/toby-spring/src/main/java/spring/practice/tobyspring/DI/NormalCalculatorService.java
@@ -1,0 +1,11 @@
+package spring.practice.tobyspring.DI;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class NormalCalculatorService implements CalculatorService {
+
+    public int add(int value1, int value2){
+        return value1+value2;
+    }
+}

--- a/toby-spring/src/main/java/spring/practice/tobyspring/DI/WeirdCalculatorService.java
+++ b/toby-spring/src/main/java/spring/practice/tobyspring/DI/WeirdCalculatorService.java
@@ -1,0 +1,16 @@
+package spring.practice.tobyspring.DI;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class WeirdCalculatorService implements CalculatorService{
+
+    private final NormalCalculatorService normalCalculatorService;
+
+    @Override
+    public int add(int value1, int value2) {
+        return normalCalculatorService.add(value1,value2)*2;
+    }
+}

--- a/toby-spring/src/test/java/spring/practice/tobyspring/DI/CalculatorTest.java
+++ b/toby-spring/src/test/java/spring/practice/tobyspring/DI/CalculatorTest.java
@@ -1,0 +1,20 @@
+package spring.practice.tobyspring.DI;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class CalculatorTest {
+
+    @Autowired
+    @Qualifier("normalCalculatorService")
+    CalculatorService calculatorService;
+
+    @Test
+    public void 정상계산기테스트(){
+        int result = calculatorService.add(1,1);
+        assert(result ==2);
+    }
+}

--- a/toby-spring/src/test/java/spring/practice/tobyspring/DI/CalculatorUpgradeTest.java
+++ b/toby-spring/src/test/java/spring/practice/tobyspring/DI/CalculatorUpgradeTest.java
@@ -1,0 +1,20 @@
+package spring.practice.tobyspring.DI;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class CalculatorUpgradeTest {
+
+    @Qualifier("weirdCalculatorService")
+    @Autowired
+    CalculatorService calculatorService;
+
+    @Test
+    public void 이상한계산기테스트(){
+         int result = calculatorService.add(1,1);
+         assert(result == 4);
+    }
+}

--- a/toby-spring/src/test/java/spring/practice/tobyspring/DI/CalculatorWithoutSpringTest.java
+++ b/toby-spring/src/test/java/spring/practice/tobyspring/DI/CalculatorWithoutSpringTest.java
@@ -1,0 +1,31 @@
+package spring.practice.tobyspring.DI;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class CalculatorWithoutSpringTest {
+
+    private CalculatorService calculatorService;
+    private int value1;
+    private int value2;
+
+    @BeforeEach
+    public void valueSetting(){
+        value1 = 1;
+        value2 = 2;
+    }
+
+    @Test
+    public void 정상계산기테스트(){
+        calculatorService = new NormalCalculatorService();
+        int result = calculatorService.add(value1, value2);
+        assert(result == (value1+value2));
+    }
+    @Test
+    public void 이상한계산기테스트(){
+        calculatorService = new WeirdCalculatorService(new NormalCalculatorService());
+        int result = calculatorService.add(value1, value2);
+        assert(result != (value1+value2));
+        assert(result == (value1+value2)*2);
+    }
+}


### PR DESCRIPTION
1. 의존성 주입 활용방안
A라는 인터페이스를 구현하는 aa라는 빈이 있다고 할 때
aa라는 빈의 어떤 메소드에 추가 기능을 추가하고 싶을 수가 있다.
이 때 굳이 구현 빈을 다시 생성하지 않고 해당 빈을 주입받아서 해당 빈의 메서드를 호출하는 A인터페이스 구현 빈을 확장해서 구현할 수 있다. 
-> 이상한 계산기 예시

2. 스프링 프레임워크를 실행시키는 `@SpringBootTest` 테스트는 서버가 올라가는데 시간이 오래 걸림
가급적이면 수동으로 의존성 주입을 시켜서 테스트를 돌리도록 코드를 짜는 것이 빠르게 테스트를 검증할 수 있다. 