### PR TITLE
예외처리(체크예외->언체크예외로 변환, SQLExceptionTranslator 활용), JdbcTemplate

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.hsqldb:hsqldb:2.3.4'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {

--- a/database/build.gradle
+++ b/database/build.gradle
@@ -20,10 +20,11 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
-    implementation 'org.projectlombok:lombok:1.18.18'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/database/src/main/java/com/example/database/repository/MemberRepository.java
+++ b/database/src/main/java/com/example/database/repository/MemberRepository.java
@@ -1,0 +1,11 @@
+package com.example.database.repository;
+
+import com.example.database.domain.Member;
+
+public interface MemberRepository {
+
+    Member save(Member member);
+    Member findById(String memberId);
+    void update(String memberId, int money);
+    void delete(String memberId);
+}

--- a/database/src/main/java/com/example/database/repository/MemberRepositoryImpl.java
+++ b/database/src/main/java/com/example/database/repository/MemberRepositoryImpl.java
@@ -1,0 +1,4 @@
+package com.example.database.repository;
+
+public class MemberRepositoryImpl {
+}

--- a/database/src/main/java/com/example/database/repository/MemberRepositoryUsingJDBCTemplate.java
+++ b/database/src/main/java/com/example/database/repository/MemberRepositoryUsingJDBCTemplate.java
@@ -1,0 +1,48 @@
+package com.example.database.repository;
+
+
+import com.example.database.domain.Member;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+@RequiredArgsConstructor
+@Slf4j
+public class MemberRepositoryUsingJDBCTemplate implements MemberRepository{
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public Member save(Member member) {
+        String sql = "insert into member(member_id, money) values(?,?)";
+        jdbcTemplate.update(sql,member.getMemberId(),member.getMoney());
+        return member;
+    }
+
+    @Override
+    public Member findById(String memberId) {
+        String sql = "select * from member where member_id=?";
+        return jdbcTemplate.queryForObject(sql,memberRowMapper(),memberId);
+    }
+
+    @Override
+    public void update(String memberId, int money) {
+        String sql = "update member set money=? where member_id=?";
+        jdbcTemplate.update(sql,money,memberId);
+    }
+
+    @Override
+    public void delete(String memberId) {
+        String sql = "delete from member where member_id=?";
+        jdbcTemplate.update(sql,memberId);
+    }
+    private RowMapper<Member> memberRowMapper(){
+        return(rs, rowNum) -> {
+            Member member = new Member();
+            member.setMemberId(rs.getString("member_id"));
+            member.setMoney(rs.getInt("money"));
+            return member;
+        };
+    }
+}

--- a/database/src/main/java/com/example/database/repository/exception/MyDBException.java
+++ b/database/src/main/java/com/example/database/repository/exception/MyDBException.java
@@ -1,0 +1,7 @@
+package com.example.database.repository.exception;
+
+public class MyDBException extends RuntimeException{
+    public MyDBException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/database/src/main/java/com/example/database/repository/exception/MyDuplicateKeyException.java
+++ b/database/src/main/java/com/example/database/repository/exception/MyDuplicateKeyException.java
@@ -1,0 +1,7 @@
+package com.example.database.repository.exception;
+
+public class MyDuplicateKeyException extends MyDBException{
+    public MyDuplicateKeyException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/database/src/test/java/com/example/database/repository/translator/ExTranslatorV1Test.java
+++ b/database/src/test/java/com/example/database/repository/translator/ExTranslatorV1Test.java
@@ -1,0 +1,96 @@
+package com.example.database.repository.translator;
+
+import com.example.database.domain.Member;
+import com.example.database.repository.exception.MyDBException;
+import com.example.database.repository.exception.MyDuplicateKeyException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.springframework.jdbc.support.JdbcUtils;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Random;
+
+import static com.example.database.connection.ConnectionConst.*;
+
+@Slf4j
+public class ExTranslatorV1Test {
+
+    Repository repository;
+    Service service;
+
+    @BeforeEach
+    void init(){
+        DriverManagerDataSource dataSource = new DriverManagerDataSource(URL,USERNAME,PASSWORD);
+        repository = new Repository(dataSource);
+        service = new Service(repository);
+    }
+
+    @Test
+    void duplicateKeySave(){
+        service.create("myId");
+        service.create("myId");
+    }
+
+    @Slf4j
+    @RequiredArgsConstructor
+    static class Service{
+        private final Repository repository;
+
+        public void create(String memberId){
+            try{
+                repository.save(new Member(memberId, 1000));
+                log.info("savedId={}",memberId);
+            }catch(MyDuplicateKeyException e){
+                log.info("키 중복, 복구 시도");
+                String retryId = generateNewId(memberId);
+                log.info("retry Id={}",retryId);
+                repository.save(new Member(retryId,1000));
+            }
+
+
+        }
+        private String generateNewId(String memberId){
+            return memberId+ new Random().nextInt(10000);
+        }
+    }
+
+    @RequiredArgsConstructor
+    static class Repository{
+        private final DataSource dataSource;
+
+        public Member save(Member member) {
+            String sql = "insert into member(member_id, money) values(?,?)";
+            Connection con = null;
+            PreparedStatement pstmt = null;
+
+            try {
+                con = dataSource.getConnection();
+                pstmt = con.prepareStatement(sql);
+                pstmt.setString(1,member.getMemberId());
+                pstmt.setInt(2,member.getMoney());
+                pstmt.executeUpdate();
+                return member;
+
+            }catch(SQLException e){
+                // h2 db
+                if(e.getErrorCode() ==23505){//h2 pk 중복 에러코드
+                    throw new MyDuplicateKeyException("중복 멤버입니다",e);
+                }
+                throw new MyDBException("db 커넥션 예외",e);
+
+            }finally{
+               JdbcUtils.closeStatement(pstmt);
+               JdbcUtils.closeConnection(con);
+
+
+            }
+        }
+    }
+}


### PR DESCRIPTION
# 예외처리
## 체크예외 -> 언체크예외로 변환
1. 언체크예외 클래스에서 RuntimeException을 extends하기
2. 생성자는 `Throwable cause` 파라미터를 받아서 생성하기 : 원본 예외 원인 파악을 위함
3. 체크예외 catch에서 생성한 언체크예외 클래스를 throw 하기 

## SQLExceptionTranslator
DB마다 SQL 예외시 예외코드가 다 다름 (중복 PK 예외가 터졌을 때, DB마다 해당 예외에 대한 예외코드를 같이 보내주는데 그 코드가 DB 구현체마다 다르다)
이를 서비스 추상화하여 Spring 에서 제공하는 것이 SQLExceptionTranslator
### 사용방법
1. 체크 예외 catch에서 throw sqlExceptionTranslator("예외상황",sql,e) 하기 -> 이 때 throw되는 예외 클래스는 자동으로 상황에 맞게 변환된 예외 클래스 (BadSQLException, DuplicateKeyException 등, 모두 spring에서 제공) 
2. 해당 예외를 받는 부분에서 catch로 따로 처리가 필요한 예외상황에서만 처리해주기
* 예시
```
catch(DuplicateKeyException e){
                log.info("키 중복, 복구 시도");
                String retryId = generateNewId(memberId);
                log.info("retry Id={}",retryId);
                repository.save(new Member(retryId,1000));
            }
```
# JdbcTemplate
반복되는 getConnection, PreparedStatement 생성, 등등 쿼리 실행 초기 작업 및 자원 닫기 try-catch-finally 문을 템플릿 콜백 패턴으로 재사용하게 지원
위의 예외처리 서비스 추상화 및 런타임 예외로 변환도 전부 지원
따라서 DB 기술과 독립적인 코드 구현 가능