### PR TITLE
단위테스트에서 mockito 활용하기

### DIFF
--- a/toby-spring/src/main/java/spring/practice/tobyspring/transaction/domain/User.java
+++ b/toby-spring/src/main/java/spring/practice/tobyspring/transaction/domain/User.java
@@ -1,10 +1,13 @@
 package spring.practice.tobyspring.transaction.domain;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@AllArgsConstructor
 public class User {
     String id;
     Level level;

--- a/toby-spring/src/main/java/spring/practice/tobyspring/transaction/service/UserService.java
+++ b/toby-spring/src/main/java/spring/practice/tobyspring/transaction/service/UserService.java
@@ -1,15 +1,17 @@
 package spring.practice.tobyspring.transaction.service;
 
+import lombok.RequiredArgsConstructor;
 import spring.practice.tobyspring.transaction.domain.Level;
 import spring.practice.tobyspring.transaction.domain.User;
 import spring.practice.tobyspring.transaction.repository.UserRepository;
 
 import java.util.List;
 
+@RequiredArgsConstructor
 public class UserService {
 
-    private final UserRepository repository = new UserRepository();
-    private final UpgradeLevelPolicy levelPolicy = new NormalUpgradeLevelPolicy();
+    private final UserRepository repository;
+    private final UpgradeLevelPolicy levelPolicy;
 
     public void upgradeLevels() throws Exception {
         List<User> users = repository.getAll();

--- a/toby-spring/src/test/java/spring/practice/tobyspring/transaction/BatchUpgradeTest.java
+++ b/toby-spring/src/test/java/spring/practice/tobyspring/transaction/BatchUpgradeTest.java
@@ -1,15 +1,35 @@
 package spring.practice.tobyspring.transaction;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import spring.practice.tobyspring.transaction.domain.Level;
 import spring.practice.tobyspring.transaction.domain.User;
+import spring.practice.tobyspring.transaction.repository.UserRepository;
+import spring.practice.tobyspring.transaction.service.NormalUpgradeLevelPolicy;
 import spring.practice.tobyspring.transaction.service.UserService;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 public class BatchUpgradeTest {
+
+    private static UserRepository userRepository;
+    private static final List<User> users = List.of(new User("test",Level.SILVER,0));
+
+    @BeforeEach
+    public void init(){
+        userRepository = mock(UserRepository.class);
+        when(userRepository.getAll()).thenReturn(this.users);
+    }
 
    static class TestService extends UserService {
         private String id;
         private TestService(String id){
+            super(userRepository, new NormalUpgradeLevelPolicy());
             this.id = id;
         }
         public void upgradeLevel(User user){
@@ -18,7 +38,7 @@ public class BatchUpgradeTest {
         }
     }
     @Test
-    public void 트랜잭션테스트() throws Exception {
+    public void 강제로예외내기() throws Exception {
        //given
        UserService service = new TestService("test");
        //then


### PR DESCRIPTION
```
UserRepository userRepository = mock(UserRepository.class);
when(userRepository.getAll()).thenReturn(this.users);
```
보통은 DB찌르는 작업은 단위테스트 시에 List 자료구조로 대체하는 것 같다
insert => list.add
update=> updateList.add
delete => list.remove(object)