### PR TITLE
다이나믹 프록시 객체 생성 및 빈 등록(InvocationHandler, BeanFactory, ProxyBeanFactory) 

### DIFF
--- a/toby-spring/src/main/java/spring/practice/tobyspring/aop/proxy/Hello.java
+++ b/toby-spring/src/main/java/spring/practice/tobyspring/aop/proxy/Hello.java
@@ -1,0 +1,7 @@
+package spring.practice.tobyspring.aop.proxy;
+
+public interface Hello {
+    public String getGreeting();
+    public void sayHello();
+    public String getDoubleGreeting();
+}

--- a/toby-spring/src/main/java/spring/practice/tobyspring/aop/proxy/HelloFactoryBean.java
+++ b/toby-spring/src/main/java/spring/practice/tobyspring/aop/proxy/HelloFactoryBean.java
@@ -1,0 +1,29 @@
+package spring.practice.tobyspring.aop.proxy;
+
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Proxy;
+
+@Component
+public class HelloFactoryBean implements FactoryBean<Object> {
+
+    @Override
+    public Object getObject() throws Exception {
+        return (Hello) Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class[]{Hello.class},
+                new UpperCaseHandler(new HelloTarget())
+        );
+    }
+
+    @Override
+    public Class<?> getObjectType() {
+        return Hello.class;
+    }
+
+    @Override
+    public boolean isSingleton() {
+        return FactoryBean.super.isSingleton();
+    }
+}

--- a/toby-spring/src/main/java/spring/practice/tobyspring/aop/proxy/HelloTarget.java
+++ b/toby-spring/src/main/java/spring/practice/tobyspring/aop/proxy/HelloTarget.java
@@ -1,0 +1,19 @@
+package spring.practice.tobyspring.aop.proxy;
+
+public class HelloTarget implements Hello{
+    static final String GREETING = "hello";
+
+    @Override
+    public String getGreeting(){
+        return GREETING;
+    }
+    @Override
+    public void sayHello(){
+        System.out.println(getGreeting());
+    }
+
+    @Override
+    public String getDoubleGreeting() {
+        return getGreeting()+getGreeting();
+    }
+}

--- a/toby-spring/src/main/java/spring/practice/tobyspring/aop/proxy/UpperCaseAdvisor.java
+++ b/toby-spring/src/main/java/spring/practice/tobyspring/aop/proxy/UpperCaseAdvisor.java
@@ -1,0 +1,16 @@
+package spring.practice.tobyspring.aop.proxy;
+
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+
+import java.lang.reflect.Method;
+import java.util.Locale;
+
+public class UpperCaseAdvisor implements MethodInterceptor {
+
+    @Override
+    public Object invoke(MethodInvocation invocation) throws Throwable {
+        String ret = (String)invocation.proceed();
+        return ret.toUpperCase();
+    }
+}

--- a/toby-spring/src/main/java/spring/practice/tobyspring/aop/proxy/UpperCaseHandler.java
+++ b/toby-spring/src/main/java/spring/practice/tobyspring/aop/proxy/UpperCaseHandler.java
@@ -1,0 +1,16 @@
+package spring.practice.tobyspring.aop.proxy;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+
+public class UpperCaseHandler implements InvocationHandler {
+    Object target;
+    public UpperCaseHandler(Object target){
+        this.target = target;
+    }
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        String ret = (String)method.invoke(target,args);
+        return ret.toUpperCase();
+    }
+}

--- a/toby-spring/src/test/java/spring/practice/tobyspring/aop/proxy/FactoryBeanTest.java
+++ b/toby-spring/src/test/java/spring/practice/tobyspring/aop/proxy/FactoryBeanTest.java
@@ -1,0 +1,17 @@
+package spring.practice.tobyspring.aop.proxy;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class FactoryBeanTest {
+
+    @Autowired
+    Hello proxiedHello;
+
+    @Test
+    public void 대문자HELLO출력(){
+        assert(proxiedHello.getGreeting()).equals("HELLO");
+    }
+}

--- a/toby-spring/src/test/java/spring/practice/tobyspring/aop/proxy/InvocationHandlerTest.java
+++ b/toby-spring/src/test/java/spring/practice/tobyspring/aop/proxy/InvocationHandlerTest.java
@@ -1,0 +1,39 @@
+package spring.practice.tobyspring.aop.proxy;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+
+public class InvocationHandlerTest {
+
+    private static Hello proxiedHello;
+    private static HelloTarget target = new HelloTarget();
+
+    @BeforeEach
+    public void 프록시객체생성(){
+        proxiedHello = (Hello) Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class[]{Hello.class},
+                new UpperCaseHandler(target)
+        );
+    }
+
+    @Test
+    public void 대문자HELLO출력(){
+        assert(proxiedHello.getGreeting()).equals("HELLO");
+        assert(target.getGreeting()).equals("hello");
+    }
+
+
+    @Test
+    public void InvocationHandler에지정된리턴값을주는메서드만가능(){
+        Assertions.assertThrows(NullPointerException.class,proxiedHello::sayHello);
+    }
+
+    @Test
+    public void 내부참조테스트(){
+        assert(proxiedHello.getDoubleGreeting()).equals("HELLOHELLO");
+    }
+}

--- a/toby-spring/src/test/java/spring/practice/tobyspring/aop/proxy/ProxyFactoryBeanTest.java
+++ b/toby-spring/src/test/java/spring/practice/tobyspring/aop/proxy/ProxyFactoryBeanTest.java
@@ -1,0 +1,44 @@
+package spring.practice.tobyspring.aop.proxy;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.aop.framework.ProxyFactoryBean;
+import org.springframework.aop.support.DefaultPointcutAdvisor;
+import org.springframework.aop.support.NameMatchMethodPointcut;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import java.lang.reflect.Proxy;
+
+@SpringBootTest
+public class ProxyFactoryBeanTest {
+
+    @TestConfiguration
+    class Config{
+        @Bean
+        public ProxyFactoryBean proxyFactoryBean(){
+            ProxyFactoryBean pfBean = new ProxyFactoryBean();
+            pfBean.setTarget(new HelloTarget());
+
+            NameMatchMethodPointcut pointcut = new NameMatchMethodPointcut();
+            pointcut.setMappedName("get*");
+
+            // proxyFactoryBean에 Advisor 생성해서 넣기
+            pfBean.addAdvisor(new DefaultPointcutAdvisor(pointcut, new UpperCaseAdvisor()));
+            return pfBean;
+        }
+
+    }
+    @Autowired
+    private Hello proxiedHello;
+
+    @Test
+    public void 대문자HELLO출력(){
+        assert(proxiedHello.getGreeting()).equals("HELLO");
+        assert(proxiedHello.getDoubleGreeting()).equals("HELLOHELLO");
+    }
+
+
+}


### PR DESCRIPTION
프록시를 만드는 데 번거로운 점 2가지가 있다
- 타깃의 인터페이스를 구현하고 위임하는 코드를 작성하기가 번거로움
- 부가기능 코드가 중복될 가능성이 많음 (예를 들어 transaction 관련 코드면 많이 쓰이니까)

**리플렉션** 
다이나믹 프록시는 위와 같은 번거로움을 해결하고자 리플렉션 기능을 활용해서 프록시를 만든다.
`invoke()` 메소드는 메소드를 실행시킬 대상 오브젝트와 파라미터 목록을 받아서 메소드를 호출한 뒤에 그 결과를 Object 타입으로 돌려준다

# InvocationHandler
다이나믹 프록시 객체의 부가기능을 담당하는 인터페이스
invoke 메소드를 오버라이드하여 부가기능을 추가하여 수행해준 뒤 결과를 return한다
이후 프록시 객체를 생성할 때 매개변수로 넘긴다
```
 proxiedHello = (Hello) Proxy.newProxyInstance(
                getClass().getClassLoader(),
                new Class[]{Hello.class},
                new UpperCaseHandler(target)
        );
```
# BeanFactory
위의 프록시객체 생성 과정을 보면 Proxy 클래스의 `newProxyInstance` 메서드를 통해 프록시 객체를 받는것을 알 수 있다
이렇게 되면 스프링 컨테이너에서 관리하기 어려워진다
스프링 컨테이너는 BeanFactory에서 `getObject` 메서드를 통해 자동으로 빈을 등록하고 관리한다
이를 활용해서 BeanFactory를 구현한 구현 클래스를 빈으로 등록하고 `getObject` 메서드를 오버라이드하여 프록시 객체를 리턴한다
# ProxyBeanFactory
위의 방법은 팩토리빈 구현 클래스를 매번 새로 만들어줘야 하는 번거로움이 있다
이에 따라 일괄적으로 여러 프록시에 등록해서 쓸 수 있는 어드바이스(부가기능), 그리고 여러 프록시를 동시에 관리할 수 있는 빈이 프록시빈팩토리이다
참고로 여기서는 `InvoactionHandler` 대신 `MethodInterpretor`를 사용하는데 거의 같은 기능을 하지만 
내부적으로 `MethodInterpretor`는 타깃 클래스에 대한 직접적인 정보를 알아야하지 않고 ProxyBeanFactory에게서 받아오기 때문에 좀 더 유연하게 활용할 수 있다. 

### 프록시 팩토리 빈의 장점과 한계
- 장점
    - 프록시 팩토리 빈의 재사용 : 프록시 팩토리 빈은 어느 타겟에나 적용할 수 있다
    - 타깃 인터페이스를 구현하는 클래스를 하나하나 만드는 번거로움이 없다
    - 하나의 핸들러 메소드만으로 수많은 메소드에 부가기능을 부여해주기 때문에 코드 중복 문제가 사라진다
- 한계
    - 한 번에 여러 클래스에 공통적인 부가기능을 제공하는 것이 불가능
    - 하나의 타깃에 여러 부가기능을 적용하려고 할 때에도 문제가 된다..새로운 부가기능을 추가하려면 새로운 프록시와 프록시 팩토리빈도 추가해야 하고 xml 설정 파일이 어마어마하게 복잡해진다
    - `Handler` 오브젝트가 프록시 팩토리 빈 갯수만큼 만들어진다 , 타깃 오브젝트가 달라지면 새로운 `Handler` 오브젝트를 만들어야 한다.
    - 매번 `setTarget` 해서 설정하는 것이 반복됨



