### PR TITLE
defaultAdvisorAutoProxyCreator 사용해서 다이나믹 프록시 빈 등록하기

### DIFF
--- a/toby-spring/src/test/java/spring/practice/tobyspring/aop/proxy/DefaultAdvisorAutoProxyCreatorTest.java
+++ b/toby-spring/src/test/java/spring/practice/tobyspring/aop/proxy/DefaultAdvisorAutoProxyCreatorTest.java
@@ -1,0 +1,50 @@
+package spring.practice.tobyspring.aop.proxy;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.aop.ClassFilter;
+import org.springframework.aop.framework.autoproxy.DefaultAdvisorAutoProxyCreator;
+import org.springframework.aop.support.NameMatchMethodPointcut;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.util.PatternMatchUtils;
+
+@SpringBootTest
+public class DefaultAdvisorAutoProxyCreatorTest {
+
+    @TestConfiguration
+    class Config{
+        @Bean
+        public DefaultAdvisorAutoProxyCreator defaultAdvisorAutoProxyCreator(){
+            return new DefaultAdvisorAutoProxyCreator();
+        }
+        @Bean
+        public NameMatchMethodPointcut nameMatchMethodPointcut(){
+            return new NameMatchClassMethodPoint();
+        }
+    }
+    public static class NameMatchClassMethodPoint extends NameMatchMethodPointcut {
+        public void setMappedClassName(String mappedClassName){
+            this.setClassFilter(new SimpleClassFilter(mappedClassName));
+        }
+         static class SimpleClassFilter implements ClassFilter {
+            String mappedName;
+            private SimpleClassFilter(String mappedName){
+                this.mappedName = mappedName;
+            }
+            public boolean matches(Class<?> clazz){
+                return PatternMatchUtils.simpleMatch(mappedName,clazz.getSimpleName());
+            }
+        }
+    }
+
+    @Autowired
+    private Hello proxiedHello;
+
+    @Test
+    public void 대문자HELLO출력(){
+        assert(proxiedHello.getGreeting()).equals("HELLO");
+        assert(proxiedHello.getDoubleGreeting()).equals("HELLOHELLO");
+    }
+}

--- a/toby-spring/src/test/java/spring/practice/tobyspring/aop/proxy/ProxyFactoryBeanTest.java
+++ b/toby-spring/src/test/java/spring/practice/tobyspring/aop/proxy/ProxyFactoryBeanTest.java
@@ -23,7 +23,6 @@ public class ProxyFactoryBeanTest {
             pfBean.setTarget(new HelloTarget());
 
             NameMatchMethodPointcut pointcut = new NameMatchMethodPointcut();
-            pointcut.setMappedName("get*");
 
             // proxyFactoryBean에 Advisor 생성해서 넣기
             pfBean.addAdvisor(new DefaultPointcutAdvisor(pointcut, new UpperCaseAdvisor()));


### PR DESCRIPTION
## 빈 후처리기를 이용한 자동 프록시 생성기

빈 후처리기는 빈 오브젝트의 프로퍼티를 강제로 수정할 수 있도 별도의 초기화 작업을 수행할 수도 있다. 심지어는 만들어진 빈 오브젝트 자체를 바꿔치기 할 수도 있다.

`DefaultAdvisorAutoProxyCreator` : 어드바이저를 이용한 자동 프록시 생성 빈 후처리기 

- 스프링이 생성하는 빈 오브젝트의 일부를 프록시로 포장하고 프록시를 빈으로 대신 등록할 수 있다.
### Process

1. DefaultAdvisorAutoProxyCreator를 빈으로 등록한다 (자동 프록시 생성기)
2. 포인트컷 클래스를 만들고 빈으로 등록한다
3. 자동 프록시 생성기는 등록된 빈 중에서 `Advisor` 인터페이스를 구현한 것을 모두 찾는다.
4.  생성되는 모든 빈에 대해 어드바이저의 포인트컷을 적용해보면서 프록시 적용 대상을 선정한다. 
5. 빈 클래스가 프록시 선정 대상이라면 프록시를 만들어 원래 빈 오브젝트와 바꿔치기한다.