### PR TITLE
aop에서 매개변수 활용하기 

### DIFF
--- a/aop/src/test/java/spring/aop/pointcut/ParameterTest.java
+++ b/aop/src/test/java/spring/aop/pointcut/ParameterTest.java
@@ -1,0 +1,48 @@
+package spring.aop.pointcut;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import spring.aop.member.MemberService;
+
+@Slf4j
+@Import(ParameterTest.ParameterAspect.class)
+@SpringBootTest
+public class ParameterTest {
+
+    @Autowired
+    MemberService memberService;
+
+    @Slf4j
+    @Aspect
+    static class ParameterAspect{
+        @Pointcut("execution(* spring.aop.member..*(..))")
+        private void allMember(){};
+
+        @Around("allMember()")
+        public Object logArgs1(ProceedingJoinPoint joinPoint) throws Throwable {
+            Object arg1 = joinPoint.getArgs()[0];
+            log.info("[logArgs1] {}, arg={}",joinPoint.getSignature(),arg1);
+            return joinPoint.proceed();
+        }
+
+        @Around("allMember() && args(arg,..)")
+        public Object logArgs2(ProceedingJoinPoint joinPoint, Object arg) throws Throwable { //String으로 받기도 가능
+            log.info("[logArgs2]{}, arg = {}",joinPoint.getSignature(),arg);
+            return joinPoint.proceed();
+        }
+
+
+    }
+
+    @Test
+    void execute(){
+        memberService.hello("hi");
+    }
+}

--- a/aop/src/test/java/spring/aop/pointcut/ParameterTest.java
+++ b/aop/src/test/java/spring/aop/pointcut/ParameterTest.java
@@ -1,14 +1,18 @@
 package spring.aop.pointcut;
 
 import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
 import org.aspectj.lang.annotation.Pointcut;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import spring.aop.annotation.ClassAop;
+import spring.aop.annotation.MethodAop;
 import spring.aop.member.MemberService;
 
 @Slf4j
@@ -36,6 +40,27 @@ public class ParameterTest {
         public Object logArgs2(ProceedingJoinPoint joinPoint, Object arg) throws Throwable { //String으로 받기도 가능
             log.info("[logArgs2]{}, arg = {}",joinPoint.getSignature(),arg);
             return joinPoint.proceed();
+        }
+
+        @Before("allMember() && this(obj)")
+        public void thisArgs(JoinPoint joinPoint, MemberService obj){
+            log.info("[this]{}, obj={}",joinPoint.getSignature(),obj.getClass());
+        }
+        @Before("allMember() && target(obj)")
+        public void targetArgs(JoinPoint joinPoint, MemberService obj){
+            log.info("[target]{}, obj={}",joinPoint.getSignature(),obj.getClass());
+        }
+        @Before("allMember() && @target(annotation)")
+        public void atTarget(JoinPoint joinPoint, ClassAop annotation){
+            log.info("[@target]{}, obj={}",joinPoint.getSignature(),annotation);
+        }
+        @Before("allMember() && @within(annotation)")
+        public void atWithin(JoinPoint joinPoint, ClassAop annotation){
+            log.info("[@within] {}, obj={}",joinPoint.getSignature(),annotation);
+        }
+        @Before("allMember() && @annotation(annotation)")
+        public void atAnnotation(JoinPoint joinPoint, MethodAop annotation){
+            log.info("[@annotation]{}, obj={}",joinPoint.getSignature(),annotation.value());
         }
 
 


### PR DESCRIPTION
# 매개변수 전달하기

## 1. 메서드 매개변수 활용

- `joinPoint.getArgs()` : Object 배열 형태로 받을 수 있음
- `args`로 받기 : 받고싶은 순서의 매개변수에 변수명 지정 → 파라미터로 받기
    
    ```java
    @Around("allMember() && args(arg,..)")
    public Object logArgs2(ProceedingJoinPoint joinPoint, Object arg)
    throws Throwable {
                log.info("[logArgs2]{}, arg={}", joinPoint.getSignature(), arg);
    return joinPoint.proceed(); 
    }
    ```
    

## 2. AOP 적용 인스턴스 받기

- `this` : AOP가 적용된 인스턴스 자체 (ex. CGLIB 프록시 객체)
- `target`: AOP를 적용할 대상이 되는 객체

```java
@Before("allMember() && this(obj)")
public void thisArgs(JoinPoint joinPoint, MemberService obj) {
            log.info("[this]{}, obj={}", joinPoint.getSignature(), 
obj.getClass());
}
@Before("allMember() && target(obj)")
public void targetArgs(JoinPoint joinPoint, MemberService obj) {
            log.info("[target]{}, obj={}", joinPoint.getSignature(), 
obj.getClass());
}
```

### 3. 어노테이션 내부 value 받기

- `@annotation` 을 통해 해당 어노테이션 받기
- `annotation.value()`

```java
@Before("allMember() && @annotation(annotation)")
public void atAnnotation(JoinPoint joinPoint, MethodAop annotation) {
            log.info("[@annotation]{}, annotationValue={}", 
joinPoint.getSignature(), annotation.value());
}
```

# JDK 동적 프록시 vs CGLIB

### 설정

JDK 동적 프록시와 CGLIB 설정은 `[application.properties](http://application.properties)` 에서 가능

```java
spring.aop.proxy-target-class=false
```

default는 CGLIB이기 때문에 `false` 를 두면 JDK 동적 프록시 방식으로 동작 (true는 CGLIB)

- JDK 동적 프록시

프록시가 인터페이스를 구현 (인터페이스 필수)

- `this` 는 proxy만을 바라보기 때문에 `memberServiceImpl`을 알지 못함


- CGLIB

target 클래스를 상속받아서 프록시 객체 생성

