### PR TITLE
Aop와 어노테이션을 활용한 logging, retry 기능 간단 구현 

### DIFF
--- a/aop/src/main/java/spring/aop/annotation/Retry.java
+++ b/aop/src/main/java/spring/aop/annotation/Retry.java
@@ -1,0 +1,12 @@
+package spring.aop.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Retry {
+    int value() default 3;
+}

--- a/aop/src/main/java/spring/aop/annotation/SampleRepository.java
+++ b/aop/src/main/java/spring/aop/annotation/SampleRepository.java
@@ -1,0 +1,15 @@
+package spring.aop.annotation;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class SampleRepository {
+
+    static int seq = 0;
+
+    public String save(String id){
+        seq++;
+        if(seq % 5 == 0) throw new IllegalStateException("예외 발생");
+        return "ok";
+    }
+}

--- a/aop/src/main/java/spring/aop/annotation/SampleRepository.java
+++ b/aop/src/main/java/spring/aop/annotation/SampleRepository.java
@@ -7,6 +7,7 @@ public class SampleRepository {
 
     static int seq = 0;
 
+    @Retry
     public String save(String id){
         seq++;
         if(seq % 5 == 0) throw new IllegalStateException("예외 발생");

--- a/aop/src/main/java/spring/aop/annotation/SampleService.java
+++ b/aop/src/main/java/spring/aop/annotation/SampleService.java
@@ -9,6 +9,7 @@ public class SampleService {
 
     private final SampleRepository sampleRepository;
 
+    @Trace
     public String save(String id){
         return sampleRepository.save(id);
     }

--- a/aop/src/main/java/spring/aop/annotation/SampleService.java
+++ b/aop/src/main/java/spring/aop/annotation/SampleService.java
@@ -1,0 +1,15 @@
+package spring.aop.annotation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SampleService {
+
+    private final SampleRepository sampleRepository;
+
+    public String save(String id){
+        return sampleRepository.save(id);
+    }
+}

--- a/aop/src/main/java/spring/aop/annotation/Trace.java
+++ b/aop/src/main/java/spring/aop/annotation/Trace.java
@@ -1,0 +1,11 @@
+package spring.aop.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Trace {
+}

--- a/aop/src/main/java/spring/aop/aspect/RetryAspect.java
+++ b/aop/src/main/java/spring/aop/aspect/RetryAspect.java
@@ -1,0 +1,29 @@
+package spring.aop.aspect;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+import spring.aop.annotation.Retry;
+
+@Slf4j
+@Aspect
+@Component
+public class RetryAspect {
+
+    @Around("@annotation(retry)")
+    public Object retry(ProceedingJoinPoint joinPoint, Retry retry) throws Throwable {
+        int maxTrial = retry.value();
+        Exception exceptionHandler = null;
+        for(int i = 1; i<=maxTrial;i++){
+            try{
+                log.info("[retry] {}/{}",i,maxTrial);
+                return joinPoint.proceed();
+            }catch(Exception e){
+                exceptionHandler = e;
+            }
+        }
+        return exceptionHandler;
+    }
+}

--- a/aop/src/main/java/spring/aop/aspect/TraceAspect.java
+++ b/aop/src/main/java/spring/aop/aspect/TraceAspect.java
@@ -1,0 +1,20 @@
+package spring.aop.aspect;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Slf4j
+@Component
+public class TraceAspect {
+
+    @Around("@annotation(spring.aop.annotation.Trace)")
+    public Object logTrace(ProceedingJoinPoint joinPoint) throws Throwable {
+        Object[] args = joinPoint.getArgs();
+        log.info("[trace] type ={} , args ={}",joinPoint.getSignature(),args);
+        return joinPoint.proceed();
+    }
+}

--- a/aop/src/test/java/spring/aop/annotation/RetryTest.java
+++ b/aop/src/test/java/spring/aop/annotation/RetryTest.java
@@ -1,0 +1,19 @@
+package spring.aop.annotation;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class RetryTest {
+
+    @Autowired
+    SampleService sampleService;
+
+    @Test
+    void execute(){
+        for(int i = 0; i<10;i++){
+            sampleService.save("test"+i);
+        }
+    }
+}

--- a/aop/src/test/java/spring/aop/annotation/TraceTest.java
+++ b/aop/src/test/java/spring/aop/annotation/TraceTest.java
@@ -1,0 +1,19 @@
+package spring.aop.annotation;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class TraceTest {
+
+    @Autowired
+    SampleService sampleService;
+
+    @Test
+    void execute(){
+        sampleService.save("test1");
+        sampleService.save("test2");
+        sampleService.save("test3");
+    }
+}


### PR DESCRIPTION
`@Trace` : 단순 logging 기능 

`@Retry` : 지정한 횟수까지 retry하게 하는 어노테이션

## Annotation value 세팅

retry할 값을 지정 → default는 3으로 뒀지만 annotation 붙일 때 변경 가능 

```java
@Target(ElementType.METHOD)
@Retention(RetentionPolicy.RUNTIME) 
public @interface Retry {
int value() default 3; 
}
```

## Aspect (AOP) 구현

- `@annotation(retry)` 로 적용된 어노테이션을 받아서 `retry.value()`로 설정된 retry횟수를 받는다
- `catch` 문에서는 Exception을 `exceptionHandler` 에 받아놨다가 retry횟수가 초과되면 해당 Exception을 return한다

```java
@Slf4j 
@Aspect
public class RetryAspect {
@Around("@annotation(retry)")
public Object doRetry(ProceedingJoinPoint joinPoint, Retry retry) throws 
Throwable {
        log.info("[retry] {} retry={}", joinPoint.getSignature(), retry);
int maxRetry = retry.value();
        Exception exceptionHolder = null;
for (int retryCount = 1; retryCount <= maxRetry; retryCount++) {
try {
                log.info("[retry] try count={}/{}", retryCount, maxRetry);
return joinPoint.proceed(); 
} catch (Exception e) {
                exceptionHolder = e;
} 
}
throw exceptionHolder; 
}
}
```